### PR TITLE
fix: fixed hover state when mouse is over the button

### DIFF
--- a/Editor/SceneViewMarkingMenu/SceneViewMarkingMenuHook.cs
+++ b/Editor/SceneViewMarkingMenu/SceneViewMarkingMenuHook.cs
@@ -97,12 +97,6 @@ namespace StansAssets.MarkingMenu
                         e.Use();
                     }
                     break;
-
-                case EventType.MouseUp:
-                    // TODO: Looks like 'EventType.MouseUp' is never called when 'EventType.MouseDown' is marked as 'used', 'EventType.ContextClick' is called instead.
-                    var visualElementEvent = UIElementsUtility.CreateEvent(e);
-                    s_MarkingMenu.SendEvent(visualElementEvent);
-                    break;
             }
 
             if (s_MarkingMenu.Active)


### PR DESCRIPTION
## Purpose of this PR
Hover state is fixed, it was wasn't working when menu is opened until user clicked 'left' mouse. Now 'hover' state works fine.
## Testing status
* No tests have been added.
### Manual testing status
Tested manually in Editor