### PR TITLE
fix: Simple mouse clicks works now (#16)

### DIFF
--- a/Editor/SceneViewMarkingMenu/SceneViewMarkingMenuHook.cs
+++ b/Editor/SceneViewMarkingMenu/SceneViewMarkingMenuHook.cs
@@ -83,6 +83,11 @@ namespace StansAssets.MarkingMenu
         {
             Event e = Event.current;
 
+            if (e.alt || e.control || e.button != 1) 
+            {
+                return;
+            }
+            
             // Open Marking Menu
             switch (e.type)
             {


### PR DESCRIPTION
## Purpose of this PR
Left click mouse button released. Right button works using Alt and Ctrl modifier keys (#16)

## Testing status
No Unit tests

### Manual testing status
Tested via Unity Editor